### PR TITLE
feat: Added sparse lazy map of die face frequencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Before finalizing any feature or publishing a new version, the agent must perfor
 1.  **Run Tests:** Execute all unit and integration tests with `dart test` and ensure they all pass.
 1.  **Verify README:** Confirm that any mentioned functionality or instructions are up to date and accurate in the `README.md` file.
 1.  **Verify LICENSE:** Confirm existence of valid `LICENSE` file.
+1.  **Verify CHANGELOG:** Confirm changes are represented in the `CHANGELOG.md` file.
 1.  **Check Pub Points:** Carefully use `pana` to calculate pub points of the package. The agent must report the results and address any suggestions or failures.
     1. Copy the directory holding the package to a temporary one because `pana` will make modifications to it, e.g.
     ```bash
@@ -27,7 +28,7 @@ Before finalizing any feature or publishing a new version, the agent must perfor
     ```bash
     dart pub global run pana ~/tmp/mypkg
     ```
-1.  **Verify Version:** Ensure the version in `pubspec.yaml` has been updated appropriately for the changes being published.
+1.  **Verify Version:** Ensure the version in `pubspec.yaml` has been updated appropriately for the changes being published. Confirm that the latest version in the `CHANGELOG.md` file matches the version in `pubspec.yaml`.
 
 ### Code Generation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0
+- Added `valueCounts` property to `RollResult` to retrieve a map of roll frequencies.
+- Added `filled` extension method on `Map<T, int>` to populate missing die faces in a frequency map.
+
 ## 0.0.2
 - Updated README title and version reference.
 - Removed publish_to restriction in pubspec.yaml.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,11 @@
 - Added `valueCounts` property to `RollResult` to retrieve a map of roll frequencies.
 - Added `filled` extension method on `Map<T, int>` to populate missing die faces in a frequency map.
 - Updated example to demonstrate usage of `valueCounts` and `filled`.
-- Expanded AGENTS.md with requirements for CHANGELOG.md
 
 ## 0.0.2
 - Updated README title and version reference.
 - Removed publish_to restriction in pubspec.yaml.
 - Added documentation URL and topics in pubspec.yaml.
-- Expanded AGENTS.md with commit message structure and lint requirements.
 
 ## 0.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.1.0
 - Added `valueCounts` property to `RollResult` to retrieve a map of roll frequencies.
 - Added `filled` extension method on `Map<T, int>` to populate missing die faces in a frequency map.
+- Updated example to demonstrate usage of `valueCounts` and `filled`.
+- Expanded AGENTS.md with requirements for CHANGELOG.md
 
 ## 0.0.2
 - Updated README title and version reference.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To use this package, add `dice_roller` as a dependency in your `pubspec.yaml` fi
 
 ```yaml
 dependencies:
-  dice_roller: ^0.0.2
+  dice_roller: ^0.1.0
 ```
 
 Then, run `dart pub get` (or `flutter pub get` if using Flutter) to install the package.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -49,27 +49,12 @@ void main() {
   while (attempt < maxAttempts) {
     attempt++;
     final catanDiceRoll = catanDiceRoller.roll();
-    var lumber = 0;
-    var brick = 0;
-    var wool = 0;
-    var grain = 0;
-    for (final face in catanDiceRoll.values) {
-      switch (face) {
-        case CatanDieFace.brick:
-          brick++;
-          break;
-        case CatanDieFace.lumber:
-          lumber++;
-          break;
-        case CatanDieFace.wool:
-          wool++;
-          break;
-        case CatanDieFace.grain:
-          grain++;
-          break;
-        default:
-      }
-    }
+    final catanDiceRollValueCounts = catanDiceRoll.valueCounts;
+    var lumber = catanDiceRollValueCounts[CatanDieFace.lumber] ?? 0;
+    var brick = catanDiceRollValueCounts[CatanDieFace.brick] ?? 0;
+    var wool = catanDiceRollValueCounts[CatanDieFace.wool] ?? 0;
+    var grain = catanDiceRollValueCounts[CatanDieFace.grain] ?? 0;
+
     if (lumber > 1 && brick > 1 && wool > 0 && grain > 0) {
       print('building a road and a settlement this roll');
       print('(${catanDiceRoll.toString()})');

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -49,11 +49,12 @@ void main() {
   while (attempt < maxAttempts) {
     attempt++;
     final catanDiceRoll = catanDiceRoller.roll();
-    final catanDiceRollValueCounts = catanDiceRoll.valueCounts;
-    var lumber = catanDiceRollValueCounts[CatanDieFace.lumber] ?? 0;
-    var brick = catanDiceRollValueCounts[CatanDieFace.brick] ?? 0;
-    var wool = catanDiceRollValueCounts[CatanDieFace.wool] ?? 0;
-    var grain = catanDiceRollValueCounts[CatanDieFace.grain] ?? 0;
+    final catanDiceRollValueCounts =
+        catanDiceRoll.valueCounts.filled(catanDiceGameDie);
+    var lumber = catanDiceRollValueCounts[CatanDieFace.lumber]!;
+    var brick = catanDiceRollValueCounts[CatanDieFace.brick]!;
+    var wool = catanDiceRollValueCounts[CatanDieFace.wool]!;
+    var grain = catanDiceRollValueCounts[CatanDieFace.grain]!;
 
     if (lumber > 1 && brick > 1 && wool > 0 && grain > 0) {
       print('building a road and a settlement this roll');

--- a/lib/dice_roller.dart
+++ b/lib/dice_roller.dart
@@ -9,6 +9,7 @@ export 'src/int_die.dart';
 export 'src/string_die.dart';
 export 'src/enum_die.dart';
 export 'src/default_dice.dart';
+export 'src/extensions.dart';
 
 /// A class that simulates rolling dice.
 ///

--- a/lib/roll_result.dart
+++ b/lib/roll_result.dart
@@ -29,6 +29,21 @@ class RollResult<T> {
         'Cannot calculate totalValue because at least one roll value was not numeric');
   }
 
+  /// A map of the counts of each unique roll value.
+  ///
+  /// Returns a sparse map where the keys are the unique dice roll
+  /// faces and the values are the number of times that face was rolled.
+  ///
+  /// Map is lazy generated for memory efficiency.
+  /// If you need to call this multiple times, consider storing the result.
+  Map<T, int> get valueCounts {
+    final counts = <T, int>{};
+    for (final roll in _rolls) {
+      counts[roll] = (counts[roll] ?? 0) + 1;
+    }
+    return counts;
+  }
+
   @override
   int get hashCode => const ListEquality<Object?>().hash(_rolls);
 

--- a/lib/roll_result.dart
+++ b/lib/roll_result.dart
@@ -34,14 +34,14 @@ class RollResult<T> {
   /// Returns a sparse map where the keys are the unique dice roll
   /// faces and the values are the number of times that face was rolled.
   ///
-  /// Map is lazy generated for memory efficiency.
+  /// The map is computed on-demand each time this getter is accessed.
   /// If you need to call this multiple times, consider storing the result.
   Map<T, int> get valueCounts {
     final counts = <T, int>{};
     for (final roll in _rolls) {
       counts[roll] = (counts[roll] ?? 0) + 1;
     }
-    return counts;
+    return Map.unmodifiable(counts);
   }
 
   @override

--- a/lib/roll_result.dart
+++ b/lib/roll_result.dart
@@ -5,13 +5,8 @@ import 'package:meta/meta.dart';
 @immutable
 class RollResult<T> {
   final List<T> _rolls;
-  late final Map<T, int> _valueCounts = () {
-    final counts = <T, int>{};
-    for (final roll in _rolls) {
-      counts[roll] = (counts[roll] ?? 0) + 1;
-    }
-    return Map<T, int>.unmodifiable(counts);
-  }();
+  late final Map<T, int> _valueCounts = Map<T, int>.unmodifiable(
+      _rolls.groupFoldBy<T, int>((roll) => roll, (prev, _) => (prev ?? 0) + 1));
 
   /// Creates a new [RollResult] with the given rolls.
   ///

--- a/lib/roll_result.dart
+++ b/lib/roll_result.dart
@@ -5,7 +5,7 @@ import 'package:meta/meta.dart';
 @immutable
 class RollResult<T> {
   final List<T> _rolls;
-  late final Map<T, int> _valueCounts = Map<T, int>.unmodifiable(
+  late final Map<T, int> _valueCounts = UnmodifiableMapView(
       _rolls.groupFoldBy<T, int>((roll) => roll, (prev, _) => (prev ?? 0) + 1));
 
   /// Creates a new [RollResult] with the given rolls.

--- a/lib/roll_result.dart
+++ b/lib/roll_result.dart
@@ -16,6 +16,8 @@ class RollResult<T> {
   /// The values of the individual rolls.
   ///
   /// Returns an unmodifiable list.
+  ///
+  /// The order of values matches the order of the rolls provided to the constructor.
   List<T> get values => _rolls;
 
   /// The sum of the values of the rolls.

--- a/lib/roll_result.dart
+++ b/lib/roll_result.dart
@@ -5,11 +5,18 @@ import 'package:meta/meta.dart';
 @immutable
 class RollResult<T> {
   final List<T> _rolls;
+  late final Map<T, int> _valueCounts = () {
+    final counts = <T, int>{};
+    for (final roll in _rolls) {
+      counts[roll] = (counts[roll] ?? 0) + 1;
+    }
+    return Map<T, int>.unmodifiable(counts);
+  }();
 
   /// Creates a new [RollResult] with the given rolls.
   ///
   /// The rolls are stored in an unmodifiable list.
-  RollResult(Iterable<T> rolls) : _rolls = List.unmodifiable(rolls);
+  RollResult(Iterable<T> rolls) : _rolls = List<T>.unmodifiable(rolls);
 
   /// The values of the individual rolls.
   ///
@@ -33,16 +40,7 @@ class RollResult<T> {
   ///
   /// Returns a sparse map where the keys are the unique dice roll
   /// faces and the values are the number of times that face was rolled.
-  ///
-  /// The map is computed on-demand each time this getter is accessed.
-  /// If you need to call this multiple times, consider storing the result.
-  Map<T, int> get valueCounts {
-    final counts = <T, int>{};
-    for (final roll in _rolls) {
-      counts[roll] = (counts[roll] ?? 0) + 1;
-    }
-    return Map.unmodifiable(counts);
-  }
+  Map<T, int> get valueCounts => _valueCounts;
 
   @override
   int get hashCode => const ListEquality<Object?>().hash(_rolls);

--- a/lib/src/die.dart
+++ b/lib/src/die.dart
@@ -11,6 +11,8 @@ abstract class Die<T> {
   /// Creates a die with the given faces.
   ///
   /// A die must have at least two faces.
+  ///
+  /// Throws [ArgumentError] if [faces] has fewer than two elements.
   Die(Iterable<T> faces) : _faces = List<T>.unmodifiable(faces) {
     if (_faces.length < 2) {
       throw ArgumentError.value(
@@ -22,6 +24,8 @@ abstract class Die<T> {
   }
 
   /// The faces of the die.
+  ///
+  /// Returns an unmodifiable list.
   List<T> get faces => _faces;
 
   @override

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -4,11 +4,17 @@ import 'die.dart';
 extension MapUtils<T> on Map<T, int> {
   /// Returns a new map containing all faces of [die] as keys.
   ///
-  /// If a face is present in this map, its value is preserved.
-  /// If a face is missing from this map, it is added with a value of `0`.
+  /// If a [die] face is present in this map, its value is preserved.
+  /// If a [die] face is missing from this map, it is added with a value of `0`.
+  /// Faces present in this map but not in [die] are dropped.
   ///
   /// This is useful for converting a sparse map of roll counts into a dense map
   /// that includes zero counts for faces that were not rolled.
+  ///
+  /// The returned map is unmodifiable while the original map is untouched.
+  ///
+  /// This method does not guard against filling in faces that were not
+  /// present in the original die.
   Map<T, int> filled(final Die<T> die) {
     final filledMap = <T, int>{};
     for (final face in die.faces) {

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -13,8 +13,8 @@ extension MapUtils<T> on Map<T, int> {
   ///
   /// The returned map is unmodifiable while the original map is untouched.
   ///
-  /// This method does not guard against filling in faces that were not
-  /// present in the original die.
+  /// Note: This method does not validate that this map's keys originated from the provided die.
+  /// It will transform any Map&lt;T, int&gt; according to the faces of the given die.
   Map<T, int> filled(final Die<T> die) {
     final filledMap = <T, int>{};
     for (final face in die.faces) {

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -1,0 +1,11 @@
+import 'die.dart';
+
+extension MapUtils<T> on Map<T, int> {
+  Map<T, int> filled(final Die<T> die) {
+    final filledMap = <T, int>{};
+    for (final face in die.faces) {
+      filledMap[face] = this[face] ?? 0;
+    }
+    return filledMap;
+  }
+}

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -1,6 +1,14 @@
 import 'die.dart';
 
+/// Utility extensions for [Map]s containing roll counts.
 extension MapUtils<T> on Map<T, int> {
+  /// Returns a new map containing all faces of [die] as keys.
+  ///
+  /// If a face is present in this map, its value is preserved.
+  /// If a face is missing from this map, it is added with a value of `0`.
+  ///
+  /// This is useful for converting a sparse map of roll counts into a dense map
+  /// that includes zero counts for faces that were not rolled.
   Map<T, int> filled(final Die<T> die) {
     final filledMap = <T, int>{};
     for (final face in die.faces) {

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -14,6 +14,6 @@ extension MapUtils<T> on Map<T, int> {
     for (final face in die.faces) {
       filledMap[face] = this[face] ?? 0;
     }
-    return filledMap;
+    return Map.unmodifiable(filledMap);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dice_roller
 description: Simulate standard and custom dice rolls in Dart/Flutter.
-version: 0.0.2
+version: 0.1.0
 repository: https://github.com/tsnash/dice-roller
 issue_tracker: https://github.com/tsnash/dice-roller/issues
 homepage: https://github.com/tsnash/dice-roller

--- a/test/dice_roller_test.dart
+++ b/test/dice_roller_test.dart
@@ -162,29 +162,25 @@ void main() {
     test('valueCounts is sparse', () {
       final result = RollResult([MyEnum.a, MyEnum.a, MyEnum.a]);
       final counts = result.valueCounts;
-      expect(counts.length, 1);
-      expect(counts[MyEnum.a], 3);
-      expect(counts[MyEnum.b], isNull);
-      expect(counts[MyEnum.c], isNull);
+      expect(counts, {MyEnum.a: 3});
     });
 
     test('valueCounts works for string rolls', () {
       final result = RollResult(['a', 'b', 'a', 'c', 'b', 'a']);
       final counts = result.valueCounts;
-      expect(counts['a'], 3);
-      expect(counts['b'], 2);
-      expect(counts['c'], 1);
-      expect(counts.length, 3);
+      expect(counts, {'a': 3, 'b': 2, 'c': 1});
     });
 
     test('valueCounts works for enum rolls', () {
       final result = RollResult(
           [MyEnum.a, MyEnum.b, MyEnum.a, MyEnum.c, MyEnum.b, MyEnum.a]);
       final counts = result.valueCounts;
-      expect(counts[MyEnum.a], 3);
-      expect(counts[MyEnum.b], 2);
-      expect(counts[MyEnum.c], 1);
-      expect(counts.length, 3);
+      expect(counts, {MyEnum.a: 3, MyEnum.b: 2, MyEnum.c: 1});
+    });
+
+    test('valueCounts is immutable', () {
+      final result = RollResult([1, 2, 3]);
+      expect(() => result.valueCounts[1] = 99, throwsUnsupportedError);
     });
   });
 

--- a/test/dice_roller_test.dart
+++ b/test/dice_roller_test.dart
@@ -247,11 +247,11 @@ void main() {
       expect(counts, {1: 4});
     });
 
-    test('filled preserves existing keys', () {
+    test('filled drops keys missing from die', () {
       final die = StringDie(['D', 'E', 'F']);
       final counts = {'A': 2, 'B': 3, 'C': 1};
       final filled = counts.filled(die);
-      expect(filled, {'A': 2, 'B': 3, 'C': 1, 'D': 0, 'E': 0, 'F': 0});
+      expect(filled, {'D': 0, 'E': 0, 'F': 0});
     });
   });
 }

--- a/test/dice_roller_test.dart
+++ b/test/dice_roller_test.dart
@@ -182,6 +182,11 @@ void main() {
       final result = RollResult([1, 2, 3]);
       expect(() => result.valueCounts[1] = 99, throwsUnsupportedError);
     });
+
+    test('valueCounts returns empty map for no rolls', () {
+      final result = RollResult<int>([]);
+      expect(result.valueCounts, isEmpty);
+    });
   });
 
   group('Die', () {

--- a/test/dice_roller_test.dart
+++ b/test/dice_roller_test.dart
@@ -149,6 +149,43 @@ void main() {
       final r = RollResult(['a', 'b']);
       expect(r.toString(), isNot(contains('totalValue')));
     });
+
+    test('valueCounts returns correct counts', () {
+      final result = RollResult([1, 2, 2, 3, 3, 3]);
+      final counts = result.valueCounts;
+      expect(counts[1], 1);
+      expect(counts[2], 2);
+      expect(counts[3], 3);
+      expect(counts.length, 3);
+    });
+
+    test('valueCounts is sparse', () {
+      final result = RollResult([MyEnum.a, MyEnum.a, MyEnum.a]);
+      final counts = result.valueCounts;
+      expect(counts.length, 1);
+      expect(counts[MyEnum.a], 3);
+      expect(counts[MyEnum.b], isNull);
+      expect(counts[MyEnum.c], isNull);
+    });
+
+    test('valueCounts works for string rolls', () {
+      final result = RollResult(['a', 'b', 'a', 'c', 'b', 'a']);
+      final counts = result.valueCounts;
+      expect(counts['a'], 3);
+      expect(counts['b'], 2);
+      expect(counts['c'], 1);
+      expect(counts.length, 3);
+    });
+
+    test('valueCounts works for enum rolls', () {
+      final result = RollResult(
+          [MyEnum.a, MyEnum.b, MyEnum.a, MyEnum.c, MyEnum.b, MyEnum.a]);
+      final counts = result.valueCounts;
+      expect(counts[MyEnum.a], 3);
+      expect(counts[MyEnum.b], 2);
+      expect(counts[MyEnum.c], 1);
+      expect(counts.length, 3);
+    });
   });
 
   group('Die', () {
@@ -177,6 +214,22 @@ void main() {
       test('${die.runtimeType} has $len faces', () {
         expect(die.faces, equals(List.generate(len, (i) => i + 1)));
       });
+    });
+  });
+
+  group('MapUtils', () {
+    test('filled populates missing keys with 0', () {
+      final die = SixSidedDie();
+      final counts = {1: 5, 6: 2};
+      final filled = counts.filled(die);
+      expect(filled, {1: 5, 2: 0, 3: 0, 4: 0, 5: 0, 6: 2});
+    });
+
+    test('filled works with custom dice types', () {
+      final die = StringDie(['A', 'B']);
+      final counts = {'A': 1};
+      final filled = counts.filled(die);
+      expect(filled, {'A': 1, 'B': 0});
     });
   });
 }

--- a/test/dice_roller_test.dart
+++ b/test/dice_roller_test.dart
@@ -232,6 +232,13 @@ void main() {
       final filled = counts.filled(die);
       expect(filled, {'A': 1, 'B': 0});
     });
+
+    test('filled returns unmodifiable map', () {
+      final die = SixSidedDie();
+      final counts = {1: 3};
+      final filled = counts.filled(die);
+      expect(() => filled[2] = 5, throwsUnsupportedError);
+    });
   });
 }
 

--- a/test/dice_roller_test.dart
+++ b/test/dice_roller_test.dart
@@ -239,6 +239,20 @@ void main() {
       final filled = counts.filled(die);
       expect(() => filled[2] = 5, throwsUnsupportedError);
     });
+
+    test('filled does not modify original map', () {
+      final die = SixSidedDie();
+      final counts = {1: 4};
+      counts.filled(die);
+      expect(counts, {1: 4});
+    });
+
+    test('filled preserves existing keys', () {
+      final die = StringDie(['D', 'E', 'F']);
+      final counts = {'A': 2, 'B': 3, 'C': 1};
+      final filled = counts.filled(die);
+      expect(filled, {'A': 2, 'B': 3, 'C': 1, 'D': 0, 'E': 0, 'F': 0});
+    });
   });
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RollResult exposes roll frequency counts.
  * Map helper fills missing die faces with zeros for dense frequency maps.
  * Package API now exposes the new helper for convenience.

* **Documentation**
  * Package bumped to 0.1.0; changelog and README updated.
  * Publishing guidance updated to require changelog/version alignment.

* **Tests**
  * Added tests for frequency counts, immutability, map filling, and related behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->